### PR TITLE
Remove tape and benchmark from production deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "benchmark": "^1.0.0",
-    "tape": "^3.5.0",
     "turf-distance": "^1.0.1",
     "turf-featurecollection": "^1.0.1",
     "turf-point": "^2.0.1",


### PR DESCRIPTION
`benchmark` and `tape` are duplicated in production deps. This may seem harmless, but breaks npm shrinkwrap workflow: npm install doesn't install them, since they are in `devDependencies`, but subsequent `npm shrinkwrap` doesn't work, because it they are not installed.
